### PR TITLE
perf: reduce allocations in SQL processor hot path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/bobg/go-generics/v3 v3.7.0
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20251221161217-02eacbe6fa7a
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
@@ -21,7 +19,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/mattn/go-sqlite3 v2.0.1+incompatible // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/bobg/go-generics/v3 v3.7.0 h1:4SJHDWqONTRcA8al6491VW/ys6061bPCcTcI7YnIHPc=
-github.com/bobg/go-generics/v3 v3.7.0/go.mod h1:wGlMLQER92clsh3cJoQjbUtUEJ03FoxnGhZjaWhf4fM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -33,8 +31,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/mattn/go-sqlite3 v2.0.1+incompatible h1:xQ15muvnzGBHpIpdrNi1DA5x0+TcBZzsIDwmw9uTHzw=
-github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -56,8 +52,6 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
@@ -106,7 +100,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -404,9 +404,8 @@ func readStatements(input io.Reader, ctx context.Context) (chan string, chan err
 	return outputCh, errCh
 }
 
-func (p Processor) processLine(ctx context.Context, line string, parser *parser.Parser, startRowIndex int) (string, error) {
+func (p Processor) processLine(ctx context.Context, line string, parser *parser.Parser, startRowIndex int, preparseResult preparsedStatement) (string, error) {
 	var tableName string
-	preparseResult := preparse(line)
 	switch v := preparseResult.(type) {
 	case nil:
 		return line, nil // passthrough: not a CREATE/INSERT
@@ -437,7 +436,8 @@ func (p Processor) processLine(ctx context.Context, line string, parser *parser.
 type lineWithOutputChannel struct {
 	line          string
 	outputChannel chan string
-	startRowIndex int // pre-computed starting row index for this statement
+	startRowIndex int                // pre-computed starting row index for this statement
+	preparsed     preparsedStatement // pre-computed statement type to avoid duplicate regex work
 }
 
 // countInsertRows quickly counts the number of value tuples in an INSERT statement
@@ -494,6 +494,7 @@ func (p Processor) processLines(input chan string, ctx context.Context) (chan ch
 				line:          line,
 				outputChannel: processedCh,
 				startRowIndex: startRowIndex,
+				preparsed:     preparsed,
 			}:
 			case <-processingCtx.Done():
 				close(processedCh)
@@ -519,7 +520,7 @@ func (p Processor) processLines(input chan string, ctx context.Context) (chan ch
 					if !ok {
 						return
 					}
-					processedLine, err := p.processLine(processingCtx, currentLine.line, stmtParser, currentLine.startRowIndex)
+					processedLine, err := p.processLine(processingCtx, currentLine.line, stmtParser, currentLine.startRowIndex, currentLine.preparsed)
 					if err != nil {
 						currentLine.outputChannel <- fmt.Sprintf("/* error: %s */\n%s", err.Error(), currentLine.line)
 						// Cancel processing context to stop all goroutines

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -23,6 +23,22 @@ import (
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 )
 
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
+func getBuffer() *bytes.Buffer {
+	buf := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return buf
+}
+
+func putBuffer(buf *bytes.Buffer) {
+	bufferPool.Put(buf)
+}
+
 type Processor struct {
 	Config               config.Config
 	tableTransformations map[string]*PreparedTableConfig
@@ -185,12 +201,15 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 						if err != nil {
 							return "", fmt.Errorf("cannot render column variables: %w", err)
 						}
-						transformedValue := new(bytes.Buffer)
+						transformedValue := getBuffer()
 						err := op.CompiledTemplate.CompiledTemplate.Execute(transformedValue, columnData)
 						if err != nil {
+							putBuffer(transformedValue)
 							return "", fmt.Errorf("cannot apply transform: %w", err)
 						}
-						currentRow[columnIdx] = ast.NewValueExpr(transformedValue.String(), mysql.UTF8Charset, mysql.UTF8Charset)
+						result := transformedValue.String()
+						putBuffer(transformedValue)
+						currentRow[columnIdx] = ast.NewValueExpr(result, mysql.UTF8Charset, mysql.UTF8Charset)
 					case "json":
 						currentValue := currentRow[columnIdx].(ast.ValueExpr).GetString()
 						columnData := &columnTemplateData{
@@ -230,21 +249,27 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 				if err != nil {
 					return "", fmt.Errorf("cannot render column variables: %w", err)
 				}
-				transformedValue := new(bytes.Buffer)
+				transformedValue := getBuffer()
 				err := tmpl.CompiledTemplate.Execute(transformedValue, columnData)
 				if err != nil {
+					putBuffer(transformedValue)
 					return "", fmt.Errorf("cannot apply transform: %w", err)
 				}
-				currentRow[columnIdx] = ast.NewValueExpr(transformedValue.String(), mysql.UTF8Charset, mysql.UTF8Charset)
+				result := transformedValue.String()
+				putBuffer(transformedValue)
+				currentRow[columnIdx] = ast.NewValueExpr(result, mysql.UTF8Charset, mysql.UTF8Charset)
 			}
 		}
 	}
-	buf := new(bytes.Buffer)
+	buf := getBuffer()
 	err = stmt.Restore(format.NewRestoreCtx(restoreFlags, buf))
 	if err != nil {
+		putBuffer(buf)
 		return "", fmt.Errorf("cannot restore insert statement: %w", err)
 	}
-	return buf.String() + ";\n", nil
+	result := buf.String() + ";\n"
+	putBuffer(buf)
+	return result, nil
 }
 
 func renderRowVariables(
@@ -253,13 +278,15 @@ func renderRowVariables(
 ) error {
 	result := make(map[string]string)
 	for _, tmpl := range templates {
-		output := new(bytes.Buffer)
+		output := getBuffer()
 		err := tmpl.CompiledTemplate.Execute(output, data)
 		if err != nil {
+			putBuffer(output)
 			return fmt.Errorf("cannot render variable '%s' template: %w", tmpl.Name, err)
 		}
 		shortName, _ := strings.CutPrefix(tmpl.Name, ".RowVariables.")
 		result[shortName] = output.String()
+		putBuffer(output)
 		data.RowVariables = result
 	}
 	return nil
@@ -270,13 +297,15 @@ func renderColumnVariables(
 	data *columnTemplateData,
 ) error {
 	for _, tmpl := range templates {
-		output := new(bytes.Buffer)
+		output := getBuffer()
 		err := tmpl.CompiledTemplate.Execute(output, data)
 		if err != nil {
+			putBuffer(output)
 			return fmt.Errorf("cannot render variable '%s' template: %w", tmpl.Name, err)
 		}
 		shortName, _ := strings.CutPrefix(tmpl.Name, ".ColumnVariables.")
 		data.ColumnVariables[shortName] = output.String()
+		putBuffer(output)
 	}
 	return nil
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -131,17 +131,17 @@ type columnTemplateData struct {
 	FieldValue      interface{}
 }
 
-func mapInsertRowToColumns(insertRow []ast.ExprNode, tableSchema TableSchema) (transformations.MappedRow, error) {
-	result := make(transformations.MappedRow)
+func mapInsertRowToColumns(insertRow []ast.ExprNode, tableSchema TableSchema, result transformations.MappedRow) error {
+	clear(result)
 	for i := range insertRow {
 		field, ok := insertRow[i].(ast.ValueExpr)
 		if !ok {
-			return nil, fmt.Errorf("cannot cast column value (%T)", insertRow[i])
+			return fmt.Errorf("cannot cast column value (%T)", insertRow[i])
 		}
 		column := tableSchema.Columns[i]
 		result[column.Name] = field.GetValue()
 	}
-	return result, nil
+	return nil
 }
 
 func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.InsertStmt, tableConfig *PreparedTableConfig, startRowIndex int) (string, error) {
@@ -152,11 +152,12 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 		return "", err
 	}
 	allInsertRows := stmt.Lists
+	reusableRow := make(transformations.MappedRow, len(schema.Columns))
 	for currentRowIndex := range allInsertRows {
 		// Use pre-computed row index (no lock needed)
 		tableRowIndex := startRowIndex + currentRowIndex
 		currentRow := allInsertRows[currentRowIndex]
-		mappedRow, err := mapInsertRowToColumns(currentRow, schema)
+		err := mapInsertRowToColumns(currentRow, schema, reusableRow)
 		if err != nil {
 			return "", fmt.Errorf("cannot map row: %w", err)
 		}
@@ -164,7 +165,7 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 			Index: tableRowIndex,
 		}
 		rowData := &rowTemplateData{
-			Row:             mappedRow,
+			Row:             reusableRow,
 			RowMeta:         rowMeta,
 			RowVariables:    make(map[string]string),
 			GlobalVariables: tableConfig.GlobalVariables,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -153,6 +153,14 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 	}
 	allInsertRows := stmt.Lists
 	reusableRow := make(transformations.MappedRow, len(schema.Columns))
+	rowData := &rowTemplateData{
+		RowVariables:    make(map[string]string),
+		GlobalVariables: tableConfig.GlobalVariables,
+		TableVariables:  tableConfig.TableVariables,
+	}
+	columnData := &columnTemplateData{
+		ColumnVariables: make(map[string]string),
+	}
 	for currentRowIndex := range allInsertRows {
 		// Use pre-computed row index (no lock needed)
 		tableRowIndex := startRowIndex + currentRowIndex
@@ -161,16 +169,10 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 		if err != nil {
 			return "", fmt.Errorf("cannot map row: %w", err)
 		}
-		rowMeta := transformations.RowMeta{
-			Index: tableRowIndex,
-		}
-		rowData := &rowTemplateData{
-			Row:             reusableRow,
-			RowMeta:         rowMeta,
-			RowVariables:    make(map[string]string),
-			GlobalVariables: tableConfig.GlobalVariables,
-			TableVariables:  tableConfig.TableVariables,
-		}
+		clear(rowData.RowVariables)
+		rowData.Row = reusableRow
+		rowData.RowMeta = transformations.RowMeta{Index: tableRowIndex}
+
 		err = renderRowVariables(
 			tableConfig.RowVariableTemplates,
 			rowData,
@@ -190,11 +192,9 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 					case "template":
 						currentColumn := currentRow[columnIdx]
 						columnVariablesTemplates := tableConfig.ColumnVariableDepsPerTemplate[op.CompiledTemplate]
-						columnData := &columnTemplateData{
-							rowTemplateData: *rowData,
-							FieldValue:      currentColumn.(ast.ValueExpr).GetString(),
-							ColumnVariables: make(map[string]string),
-						}
+						columnData.rowTemplateData = *rowData
+						columnData.FieldValue = currentColumn.(ast.ValueExpr).GetString()
+						clear(columnData.ColumnVariables)
 						err = renderColumnVariables(columnVariablesTemplates, columnData)
 						if err != nil {
 							return "", fmt.Errorf("cannot render column variables: %w", err)
@@ -210,11 +210,9 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 						currentRow[columnIdx] = ast.NewValueExpr(result, mysql.UTF8Charset, mysql.UTF8Charset)
 					case "json":
 						currentValue := currentRow[columnIdx].(ast.ValueExpr).GetString()
-						columnData := &columnTemplateData{
-							rowTemplateData: *rowData,
-							FieldValue:      currentValue,
-							ColumnVariables: make(map[string]string),
-						}
+						columnData.rowTemplateData = *rowData
+						columnData.FieldValue = currentValue
+						clear(columnData.ColumnVariables)
 						transformedJSON, err := applyJsonTransform(currentValue, op.JsonFields, columnData)
 						if err != nil {
 							return "", fmt.Errorf("JSON transform failed for column '%s': %w", columnSchema.Name, err)
@@ -236,11 +234,9 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 					return "", fmt.Errorf("cannot get transformation function: %w", err)
 				}
 				columnVariablesTemplates := tableConfig.ColumnVariableDepsPerTemplate[tmpl]
-				columnData := &columnTemplateData{
-					rowTemplateData: *rowData,
-					FieldValue:      currentColumn.(ast.ValueExpr).GetString(),
-					ColumnVariables: make(map[string]string),
-				}
+				columnData.rowTemplateData = *rowData
+				columnData.FieldValue = currentColumn.(ast.ValueExpr).GetString()
+				clear(columnData.ColumnVariables)
 				err = renderColumnVariables(columnVariablesTemplates, columnData)
 				if err != nil {
 					return "", fmt.Errorf("cannot render column variables: %w", err)
@@ -272,7 +268,6 @@ func renderRowVariables(
 	templates []*templates.Template,
 	data *rowTemplateData,
 ) error {
-	result := make(map[string]string)
 	for _, tmpl := range templates {
 		output := getBuffer()
 		err := tmpl.CompiledTemplate.Execute(output, data)
@@ -281,9 +276,8 @@ func renderRowVariables(
 			return fmt.Errorf("cannot render variable '%s' template: %w", tmpl.Name, err)
 		}
 		shortName, _ := strings.CutPrefix(tmpl.Name, ".RowVariables.")
-		result[shortName] = output.String()
+		data.RowVariables[shortName] = output.String()
 		putBuffer(output)
-		data.RowVariables = result
 	}
 	return nil
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/bobg/go-generics/v3/slices"
 	"github.com/duffpl/go-mdp/v2/config"
 	"github.com/duffpl/go-mdp/v2/templates"
 	"github.com/duffpl/go-mdp/v2/transformations"
@@ -189,9 +188,7 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 					switch op.Type {
 					case "template":
 						currentColumn := currentRow[columnIdx]
-						columnVariablesTemplates := slices.Filter(op.CompiledTemplate.Dependencies, func(tmpl *templates.Template) bool {
-							return strings.HasPrefix(tmpl.Name, ".ColumnVariables")
-						})
+						columnVariablesTemplates := tableConfig.ColumnVariableDepsPerTemplate[op.CompiledTemplate]
 						columnData := &columnTemplateData{
 							rowTemplateData: *rowData,
 							FieldValue:      currentColumn.(ast.ValueExpr).GetString(),
@@ -237,9 +234,7 @@ func (p *Processor) processInsertStatement(ctx context.Context, stmt *ast.Insert
 				if err != nil {
 					return "", fmt.Errorf("cannot get transformation function: %w", err)
 				}
-				columnVariablesTemplates := slices.Filter(tmpl.Dependencies, func(tmpl *templates.Template) bool {
-					return strings.HasPrefix(tmpl.Name, ".ColumnVariables")
-				})
+				columnVariablesTemplates := tableConfig.ColumnVariableDepsPerTemplate[tmpl]
 				columnData := &columnTemplateData{
 					rowTemplateData: *rowData,
 					FieldValue:      currentColumn.(ast.ValueExpr).GetString(),
@@ -624,12 +619,13 @@ type PreparedColumnOp struct {
 }
 
 type PreparedTableConfig struct {
-	ColumnOps               map[string][]PreparedColumnOp
-	ColumnTemplates         map[string][]*templates.Template
-	ColumnVariableTemplates map[string]*templates.Template
-	GlobalVariables         map[string]string
-	TableVariables          map[string]string
-	RowVariableTemplates    []*templates.Template
+	ColumnOps                     map[string][]PreparedColumnOp
+	ColumnTemplates               map[string][]*templates.Template
+	ColumnVariableTemplates       map[string]*templates.Template
+	ColumnVariableDepsPerTemplate map[*templates.Template][]*templates.Template
+	GlobalVariables               map[string]string
+	TableVariables                map[string]string
+	RowVariableTemplates          []*templates.Template
 }
 
 func prepareTableConfigs(configData config.Config) (map[string]*PreparedTableConfig, error) {
@@ -748,17 +744,48 @@ func prepareTableConfigs(configData config.Config) (map[string]*PreparedTableCon
 					ops[mapping.opIndex].CompiledTemplate = compiledTmpl
 				}
 			}
+			// Precompute column variable dependency filter per template
+			columnVariableDeps := make(map[*templates.Template][]*templates.Template)
+			for _, colTemplates := range columnTemplates {
+				for _, tmpl := range colTemplates {
+					if tmpl == nil {
+						continue
+					}
+					var deps []*templates.Template
+					for _, dep := range tmpl.Dependencies {
+						if strings.HasPrefix(dep.Name, ".ColumnVariables") {
+							deps = append(deps, dep)
+						}
+					}
+					columnVariableDeps[tmpl] = deps
+				}
+			}
+			// Also precompute for ColumnOps templates
+			for _, ops := range columnOps {
+				for _, op := range ops {
+					if op.Type == "template" && op.CompiledTemplate != nil {
+						var deps []*templates.Template
+						for _, dep := range op.CompiledTemplate.Dependencies {
+							if strings.HasPrefix(dep.Name, ".ColumnVariables") {
+								deps = append(deps, dep)
+							}
+						}
+						columnVariableDeps[op.CompiledTemplate] = deps
+					}
+				}
+			}
 			rendererTableVariables, err := renderTableVariables(tableVariablesTemplates, renderedGlobalVariables)
 			if err != nil {
 				return nil, fmt.Errorf("cannot render table variables: %w", err)
 			}
 			preparedTableConfig := &PreparedTableConfig{
-				GlobalVariables:         renderedGlobalVariables,
-				TableVariables:          rendererTableVariables,
-				RowVariableTemplates:    rowVariableTemplates,
-				ColumnVariableTemplates: columnVariableTemplates,
-				ColumnTemplates:         columnTemplates,
-				ColumnOps:               columnOps,
+				GlobalVariables:               renderedGlobalVariables,
+				TableVariables:                rendererTableVariables,
+				RowVariableTemplates:          rowVariableTemplates,
+				ColumnVariableTemplates:       columnVariableTemplates,
+				ColumnVariableDepsPerTemplate: columnVariableDeps,
+				ColumnTemplates:               columnTemplates,
+				ColumnOps:                     columnOps,
 			}
 			return preparedTableConfig, nil
 		}()


### PR DESCRIPTION
## Summary
- Add `sync.Pool` for `bytes.Buffer` reuse, precompute column variable dependency filters at setup time, and reuse `MappedRow` map across rows
- Reuse `rowTemplateData` / `columnTemplateData` structs across iterations instead of allocating per row/column
- Pass preparse result through the pipeline to avoid duplicate regex work, and remove unused `go-generics`/`logrus` dependencies

## Benchmarks (10,000 rows)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **B/op** | 157.8 MiB | 127.5 MiB | **-19.15%** |
| **allocs/op** | 2.328M | 1.967M | **-15.51%** |
| **sec/op** | 50.49ms | 50.24ms | ~stable |

All improvements scale linearly across benchmark sizes (100 to 2M rows).

## Test plan
- [x] All 25 processor tests pass after each change
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Benchmarks verified at each step with `benchstat`
- [x] All benchmark sizes (100-2M rows) verified for consistent scaling