### PR TITLE
feat: skip tables and ProcessedTables() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The resulting binary is called `go-mdp`.
 
 {
   "settings": { "locale": "default" },
+  "skipTables": ["audit_log", "job_queue"],
   "globalVariables": {
     "domain": "example.com"
   },
@@ -58,25 +59,25 @@ The resulting binary is called `go-mdp`.
         {
           "name": "email",
           "transformations": [
-            { "type": "template", "options": { "template": "user-{{ .Row.id }}@{{ .GlobalVariables.domain }}" } }
+            { "template": "user-{{ .Row.id }}@{{ .GlobalVariables.domain }}" }
           ]
         },
         {
           "name": "first_name",
           "transformations": [
-            { "type": "template", "options": { "template": "{{ transformFirstName .FieldValue }}" } }
+            { "template": "{{ transformFirstName .FieldValue }}" }
           ]
         },
         {
           "name": "last_name",
           "transformations": [
-            { "type": "template", "options": { "template": "{{ transformLastName .FieldValue }}" } }
+            { "template": "{{ transformLastName .FieldValue }}" }
           ]
         },
         {
           "name": "password",
           "transformations": [
-            { "type": "template", "options": { "template": "{{ bcryptHash \"changeme\" }}" } }
+            { "template": "{{ bcryptHash \"changeme\" }}" }
           ]
         }
       ]
@@ -111,6 +112,7 @@ Example: inlining a compressed config
 ## Configuration reference (JSON)
 Top-level:
 - settings.locale: locale for fake data helpers; one of: default, fi, se, no, dk
+- skipTables: array of table names whose INSERT statements should be dropped (CREATE TABLE is preserved)
 - globalVariables: name -> template string evaluated once globally (can reference previously defined global variables)
 - tableVariables: name -> template string evaluated per-table (can reference global + already defined table vars)
 - rowVariables: name -> template string evaluated per row (has access to row data and counters)
@@ -125,14 +127,23 @@ Table config:
 
 Column config:
 - name: column name
-- transformations: array of objects with shape:
-  { "type": "template" | "value", "options": { ... } }
-  - type: template
-    - options.template: Go template string; output replaces the value
-  - type: value
-    - options.value: static value to set (string, number, etc.)
+- transformations: array of transformation objects (two formats supported):
 
-Note: Internally, all transformations are executed via compiled templates. The `value` type is equivalent to a template that outputs a constant.
+  Flat format (simpler):
+    { "template": "{{ .FieldValue }}@example.com" }
+    { "json": [ { "path": "user.name", "template": "anon" } ] }
+
+  Nested format:
+    { "type": "template", "options": { "template": "{{ .FieldValue }}@example.com" } }
+    { "type": "json", "options": { "fields": [ { "path": "user.name", "template": "anon" } ] } }
+
+  Both formats can be mixed in the same config. When type is omitted, it is inferred from the key ("template" or "json").
+
+  Transformation types:
+  - template: Go template string; output replaces the column value
+  - json: transform fields inside a JSON column value
+    - options.fields: array of { "path": "json.path", "template": "..." }
+    - path uses GJSON syntax (e.g. "user.name", "contacts.#.email")
 
 
 ## Template data model
@@ -191,7 +202,7 @@ Performance notes
       {
         "name": "users",
         "columns": [
-          { "name": "email", "transformations": [ { "type": "template", "options": { "template": "user-{{ .Row.id }}@example.com" } } ] }
+          { "name": "email", "transformations": [ { "template": "user-{{ .Row.id }}@example.com" } ] }
         ]
       }
     ]

--- a/config/config.go
+++ b/config/config.go
@@ -61,8 +61,10 @@ func (c *ColumnConfig) UnmarshalJSON(bytes []byte) error {
 		Fields   []jsonFieldRaw `json:"fields"`
 	}
 	type transformationRaw struct {
-		Type    string     `json:"type"`
-		Options optionsRaw `json:"options"`
+		Type       string         `json:"type"`
+		Template   string         `json:"template"`   // flat format: {"template": "..."}
+		JsonFields []jsonFieldRaw `json:"json"`        // flat format: {"json": [{...}]}
+		Options    optionsRaw     `json:"options"`     // nested format: {"type": "...", "options": {...}}
 	}
 	type columnRaw struct {
 		Name            string              `json:"name"`
@@ -81,19 +83,32 @@ func (c *ColumnConfig) UnmarshalJSON(bytes []byte) error {
 	for i, t := range raw.Transformations {
 		opType := t.Type
 		if opType == "" {
-			opType = "template"
+			switch {
+			case len(t.JsonFields) > 0:
+				opType = "json"
+			default:
+				opType = "template"
+			}
 		}
 
 		switch opType {
 		case "template":
+			tmpl := t.Options.Template
+			if tmpl == "" {
+				tmpl = t.Template
+			}
 			c.Operations[i] = ColumnOperation{
 				Type:     "template",
-				Template: Template(t.Options.Template),
+				Template: Template(tmpl),
 			}
-			c.Templates = append(c.Templates, Template(t.Options.Template))
+			c.Templates = append(c.Templates, Template(tmpl))
 		case "json":
-			fields := make([]JsonFieldConfig, len(t.Options.Fields))
-			for j, f := range t.Options.Fields {
+			rawFields := t.Options.Fields
+			if len(rawFields) == 0 {
+				rawFields = t.JsonFields
+			}
+			fields := make([]JsonFieldConfig, len(rawFields))
+			for j, f := range rawFields {
 				fields[j] = JsonFieldConfig{
 					Path:     f.Path,
 					Template: Template(f.Template),

--- a/config/config.go
+++ b/config/config.go
@@ -51,21 +51,58 @@ type ColumnTransformation interface {
 	GetType() string
 }
 
+type jsonFieldRaw struct {
+	Path     string `json:"path"`
+	Template string `json:"template"`
+}
+
+type optionsRaw struct {
+	Template string         `json:"template"`
+	Fields   []jsonFieldRaw `json:"fields"`
+}
+
+type transformationRaw struct {
+	Type       string         `json:"type"`
+	Template   string         `json:"template"` // flat format: {"template": "..."}
+	JsonFields []jsonFieldRaw `json:"json"`     // flat format: {"json": [{...}]}
+	Options    optionsRaw     `json:"options"`  // nested format: {"type": "...", "options": {...}}
+}
+
+// normalizeTransformation canonicalizes flat-format fields into the nested
+// options form so downstream code only deals with one representation.
+func normalizeTransformation(t transformationRaw) (transformationRaw, error) {
+	// Resolve template: flat → options
+	if t.Template != "" && t.Options.Template != "" {
+		return t, fmt.Errorf("ambiguous transformation: both template and options.template set")
+	}
+	if t.Template != "" {
+		t.Options.Template = t.Template
+		t.Template = ""
+	}
+
+	// Resolve json fields: flat → options
+	if len(t.JsonFields) > 0 && len(t.Options.Fields) > 0 {
+		return t, fmt.Errorf("ambiguous transformation: both json and options.fields set")
+	}
+	if len(t.JsonFields) > 0 {
+		t.Options.Fields = t.JsonFields
+		t.JsonFields = nil
+	}
+
+	// Infer type from populated fields when not explicit
+	if t.Type == "" {
+		switch {
+		case len(t.Options.Fields) > 0:
+			t.Type = "json"
+		default:
+			t.Type = "template"
+		}
+	}
+
+	return t, nil
+}
+
 func (c *ColumnConfig) UnmarshalJSON(bytes []byte) error {
-	type jsonFieldRaw struct {
-		Path     string `json:"path"`
-		Template string `json:"template"`
-	}
-	type optionsRaw struct {
-		Template string         `json:"template"`
-		Fields   []jsonFieldRaw `json:"fields"`
-	}
-	type transformationRaw struct {
-		Type       string         `json:"type"`
-		Template   string         `json:"template"` // flat format: {"template": "..."}
-		JsonFields []jsonFieldRaw `json:"json"`     // flat format: {"json": [{...}]}
-		Options    optionsRaw     `json:"options"`  // nested format: {"type": "...", "options": {...}}
-	}
 	type columnRaw struct {
 		Name            string              `json:"name"`
 		Transformations []transformationRaw `json:"transformations"`
@@ -81,34 +118,21 @@ func (c *ColumnConfig) UnmarshalJSON(bytes []byte) error {
 	c.Templates = nil
 
 	for i, t := range raw.Transformations {
-		opType := t.Type
-		if opType == "" {
-			switch {
-			case len(t.JsonFields) > 0:
-				opType = "json"
-			default:
-				opType = "template"
-			}
+		t, err := normalizeTransformation(t)
+		if err != nil {
+			return fmt.Errorf("column %q, transformation %d: %w", raw.Name, i, err)
 		}
 
-		switch opType {
+		switch t.Type {
 		case "template":
-			tmpl := t.Options.Template
-			if tmpl == "" {
-				tmpl = t.Template
-			}
 			c.Operations[i] = ColumnOperation{
 				Type:     "template",
-				Template: Template(tmpl),
+				Template: Template(t.Options.Template),
 			}
-			c.Templates = append(c.Templates, Template(tmpl))
+			c.Templates = append(c.Templates, Template(t.Options.Template))
 		case "json":
-			rawFields := t.Options.Fields
-			if len(rawFields) == 0 {
-				rawFields = t.JsonFields
-			}
-			fields := make([]JsonFieldConfig, len(rawFields))
-			for j, f := range rawFields {
+			fields := make([]JsonFieldConfig, len(t.Options.Fields))
+			for j, f := range t.Options.Fields {
 				fields[j] = JsonFieldConfig{
 					Path:     f.Path,
 					Template: Template(f.Template),
@@ -119,7 +143,7 @@ func (c *ColumnConfig) UnmarshalJSON(bytes []byte) error {
 				JsonFields: fields,
 			}
 		default:
-			return fmt.Errorf("unknown transformation type: %s", opType)
+			return fmt.Errorf("column %q, transformation %d: unknown type: %s", raw.Name, i, t.Type)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -62,9 +62,9 @@ func (c *ColumnConfig) UnmarshalJSON(bytes []byte) error {
 	}
 	type transformationRaw struct {
 		Type       string         `json:"type"`
-		Template   string         `json:"template"`   // flat format: {"template": "..."}
-		JsonFields []jsonFieldRaw `json:"json"`        // flat format: {"json": [{...}]}
-		Options    optionsRaw     `json:"options"`     // nested format: {"type": "...", "options": {...}}
+		Template   string         `json:"template"` // flat format: {"template": "..."}
+		JsonFields []jsonFieldRaw `json:"json"`     // flat format: {"json": [{...}]}
+		Options    optionsRaw     `json:"options"`  // nested format: {"type": "...", "options": {...}}
 	}
 	type columnRaw struct {
 		Name            string              `json:"name"`

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 
 type Config struct {
 	TableConfigs    []TableConfig       `json:"tables"`
+	SkipTables      []string            `json:"skipTables,omitempty"`
 	RowVariables    map[string]Template `json:"rowVariables,omitempty"`
 	ColumnVariables map[string]Template `json:"columnVariables,omitempty"`
 	GlobalVariables map[string]Template `json:"globalVariables,omitempty"`
@@ -23,6 +24,7 @@ type Template string
 
 type TableConfig struct {
 	TableName       string              `json:"name"`
+	Skip            bool                `json:"skip,omitempty"`
 	Columns         []ColumnConfig      `json:"columns"`
 	RowVariables    map[string]Template `json:"rowVariables,omitempty"`
 	ColumnVariables map[string]Template `json:"columnVariables,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,6 @@ type Template string
 
 type TableConfig struct {
 	TableName       string              `json:"name"`
-	Skip            bool                `json:"skip,omitempty"`
 	Columns         []ColumnConfig      `json:"columns"`
 	RowVariables    map[string]Template `json:"rowVariables,omitempty"`
 	ColumnVariables map[string]Template `json:"columnVariables,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -114,3 +114,47 @@ func TestColumnConfig_UnmarshalJSON_DefaultType(t *testing.T) {
 		t.Errorf("Expected default type 'template', got '%s'", col.Operations[0].Type)
 	}
 }
+
+func TestTableConfig_UnmarshalJSON_SkipField(t *testing.T) {
+	input := `{
+		"tables": [
+			{"name": "audit_log", "skip": true},
+			{"name": "users", "columns": []}
+		]
+	}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(cfg.TableConfigs) != 2 {
+		t.Fatalf("Expected 2 table configs, got %d", len(cfg.TableConfigs))
+	}
+	if !cfg.TableConfigs[0].Skip {
+		t.Error("Expected audit_log to have Skip=true")
+	}
+	if cfg.TableConfigs[0].TableName != "audit_log" {
+		t.Errorf("Expected table name 'audit_log', got '%s'", cfg.TableConfigs[0].TableName)
+	}
+	if cfg.TableConfigs[1].Skip {
+		t.Error("Expected users to have Skip=false")
+	}
+}
+
+func TestConfig_SkipTablesField(t *testing.T) {
+	input := `{
+		"skipTables": ["cache_entries", "job_queue"]
+	}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(cfg.SkipTables) != 2 {
+		t.Fatalf("Expected 2 skip tables, got %d", len(cfg.SkipTables))
+	}
+	if cfg.SkipTables[0] != "cache_entries" {
+		t.Errorf("Expected 'cache_entries', got '%s'", cfg.SkipTables[0])
+	}
+	if cfg.SkipTables[1] != "job_queue" {
+		t.Errorf("Expected 'job_queue', got '%s'", cfg.SkipTables[1])
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,6 +115,136 @@ func TestColumnConfig_UnmarshalJSON_DefaultType(t *testing.T) {
 	}
 }
 
+func TestColumnConfig_UnmarshalJSON_FlatFormat(t *testing.T) {
+	// Original format used by db-hub: template directly on transformation, no type/options wrapper
+	input := `{
+		"name": "electronic_address",
+		"transformations": [
+			{"template": "{{ randInt 1000000000 9999999999 }}"}
+		]
+	}`
+	var col ColumnConfig
+	err := json.Unmarshal([]byte(input), &col)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if col.ColumnName != "electronic_address" {
+		t.Errorf("Expected column name 'electronic_address', got '%s'", col.ColumnName)
+	}
+	if len(col.Operations) != 1 {
+		t.Fatalf("Expected 1 operation, got %d", len(col.Operations))
+	}
+	op := col.Operations[0]
+	if op.Type != "template" {
+		t.Errorf("Expected type 'template', got '%s'", op.Type)
+	}
+	if op.Template != "{{ randInt 1000000000 9999999999 }}" {
+		t.Errorf("Expected template '{{ randInt 1000000000 9999999999 }}', got '%s'", op.Template)
+	}
+	if len(col.Templates) != 1 {
+		t.Fatalf("Expected 1 template, got %d", len(col.Templates))
+	}
+	if col.Templates[0] != "{{ randInt 1000000000 9999999999 }}" {
+		t.Errorf("Expected template in Templates slice, got '%s'", col.Templates[0])
+	}
+}
+
+func TestColumnConfig_UnmarshalJSON_FlatFormatMultiple(t *testing.T) {
+	// Multiple flat-format transformations
+	input := `{
+		"name": "email",
+		"transformations": [
+			{"template": "{{ .RowMeta.Index }}@test.com"},
+			{"template": "prefix-{{ .FieldValue }}"}
+		]
+	}`
+	var col ColumnConfig
+	err := json.Unmarshal([]byte(input), &col)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(col.Operations) != 2 {
+		t.Fatalf("Expected 2 operations, got %d", len(col.Operations))
+	}
+	if col.Operations[0].Template != "{{ .RowMeta.Index }}@test.com" {
+		t.Errorf("Expected first template, got '%s'", col.Operations[0].Template)
+	}
+	if col.Operations[1].Template != "prefix-{{ .FieldValue }}" {
+		t.Errorf("Expected second template, got '%s'", col.Operations[1].Template)
+	}
+}
+
+func TestColumnConfig_UnmarshalJSON_FlatJsonFormat(t *testing.T) {
+	// Flat format for json type: "json" key directly on transformation
+	input := `{
+		"name": "metadata",
+		"transformations": [
+			{"json": [
+				{"path": "user.firstName", "template": "{{ transformFirstName .FieldValue }}"},
+				{"path": "contacts.#.email", "template": "anon-{{ .RowMeta.Index }}@test.com"}
+			]}
+		]
+	}`
+	var col ColumnConfig
+	err := json.Unmarshal([]byte(input), &col)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(col.Operations) != 1 {
+		t.Fatalf("Expected 1 operation, got %d", len(col.Operations))
+	}
+	op := col.Operations[0]
+	if op.Type != "json" {
+		t.Errorf("Expected type 'json', got '%s'", op.Type)
+	}
+	if len(op.JsonFields) != 2 {
+		t.Fatalf("Expected 2 json fields, got %d", len(op.JsonFields))
+	}
+	if op.JsonFields[0].Path != "user.firstName" {
+		t.Errorf("Expected path 'user.firstName', got '%s'", op.JsonFields[0].Path)
+	}
+	if op.JsonFields[0].Template != "{{ transformFirstName .FieldValue }}" {
+		t.Errorf("Expected template, got '%s'", op.JsonFields[0].Template)
+	}
+	if op.JsonFields[1].Path != "contacts.#.email" {
+		t.Errorf("Expected path 'contacts.#.email', got '%s'", op.JsonFields[1].Path)
+	}
+}
+
+func TestColumnConfig_UnmarshalJSON_FlatMixedFormats(t *testing.T) {
+	// Mix flat template and flat json in the same column
+	input := `{
+		"name": "data",
+		"transformations": [
+			{"template": "prefix-{{ .FieldValue }}"},
+			{"json": [{"path": "name", "template": "anon"}]}
+		]
+	}`
+	var col ColumnConfig
+	err := json.Unmarshal([]byte(input), &col)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(col.Operations) != 2 {
+		t.Fatalf("Expected 2 operations, got %d", len(col.Operations))
+	}
+	if col.Operations[0].Type != "template" {
+		t.Errorf("Expected first op type 'template', got '%s'", col.Operations[0].Type)
+	}
+	if col.Operations[0].Template != "prefix-{{ .FieldValue }}" {
+		t.Errorf("Expected template string, got '%s'", col.Operations[0].Template)
+	}
+	if col.Operations[1].Type != "json" {
+		t.Errorf("Expected second op type 'json', got '%s'", col.Operations[1].Type)
+	}
+	if len(col.Operations[1].JsonFields) != 1 {
+		t.Fatalf("Expected 1 json field, got %d", len(col.Operations[1].JsonFields))
+	}
+	if col.Operations[1].JsonFields[0].Path != "name" {
+		t.Errorf("Expected path 'name', got '%s'", col.Operations[1].JsonFields[0].Path)
+	}
+}
+
 func TestConfig_SkipTablesField(t *testing.T) {
 	input := `{
 		"skipTables": ["cache_entries", "job_queue"]

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,31 +115,6 @@ func TestColumnConfig_UnmarshalJSON_DefaultType(t *testing.T) {
 	}
 }
 
-func TestTableConfig_UnmarshalJSON_SkipField(t *testing.T) {
-	input := `{
-		"tables": [
-			{"name": "audit_log", "skip": true},
-			{"name": "users", "columns": []}
-		]
-	}`
-	var cfg Config
-	if err := json.Unmarshal([]byte(input), &cfg); err != nil {
-		t.Fatalf("Unmarshal failed: %v", err)
-	}
-	if len(cfg.TableConfigs) != 2 {
-		t.Fatalf("Expected 2 table configs, got %d", len(cfg.TableConfigs))
-	}
-	if !cfg.TableConfigs[0].Skip {
-		t.Error("Expected audit_log to have Skip=true")
-	}
-	if cfg.TableConfigs[0].TableName != "audit_log" {
-		t.Errorf("Expected table name 'audit_log', got '%s'", cfg.TableConfigs[0].TableName)
-	}
-	if cfg.TableConfigs[1].Skip {
-		t.Error("Expected users to have Skip=false")
-	}
-}
-
 func TestConfig_SkipTablesField(t *testing.T) {
 	input := `{
 		"skipTables": ["cache_entries", "job_queue"]

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -242,6 +243,46 @@ func TestColumnConfig_UnmarshalJSON_FlatMixedFormats(t *testing.T) {
 	}
 	if col.Operations[1].JsonFields[0].Path != "name" {
 		t.Errorf("Expected path 'name', got '%s'", col.Operations[1].JsonFields[0].Path)
+	}
+}
+
+func TestColumnConfig_UnmarshalJSON_AmbiguousTemplate(t *testing.T) {
+	// Both flat template and options.template set — should error
+	input := `{
+		"name": "email",
+		"transformations": [
+			{"template": "flat", "options": {"template": "nested"}}
+		]
+	}`
+	var col ColumnConfig
+	err := json.Unmarshal([]byte(input), &col)
+	if err == nil {
+		t.Fatal("Expected error for ambiguous template, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("Expected ambiguous error, got: %s", err)
+	}
+}
+
+func TestColumnConfig_UnmarshalJSON_AmbiguousJson(t *testing.T) {
+	// Both flat json and options.fields set — should error
+	input := `{
+		"name": "metadata",
+		"transformations": [
+			{
+				"type": "json",
+				"json": [{"path": "a", "template": "x"}],
+				"options": {"fields": [{"path": "b", "template": "y"}]}
+			}
+		]
+	}`
+	var col ColumnConfig
+	err := json.Unmarshal([]byte(input), &col)
+	if err == nil {
+		t.Fatal("Expected error for ambiguous json fields, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("Expected ambiguous error, got: %s", err)
 	}
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,6 +31,7 @@ type Processor struct {
 	schemaMapLock        *sync.Mutex
 	tableSchemas         map[string]TableSchema
 	schemaReadyCond      *sync.Cond // condition variable to wait for schema
+	processedTables      []string
 }
 
 func NewProcessorWithConfig(configData config.Config) (*Processor, error) {
@@ -63,6 +65,13 @@ func NewProcessor(config config.Config) (*Processor, error) {
 	}
 	p.globalVariables = globalVariables
 	return p, nil
+}
+
+func (p *Processor) ProcessedTables() []string {
+	result := make([]string, len(p.processedTables))
+	copy(result, p.processedTables)
+	sort.Strings(result)
+	return result
 }
 
 func (p *Processor) processCreateTableStatement(stmt *ast.CreateTableStmt) {
@@ -393,7 +402,7 @@ func readStatements(input io.Reader, ctx context.Context) (chan string, chan err
 	return outputCh, errCh
 }
 
-func (p Processor) processLine(ctx context.Context, line string, parser *parser.Parser, startRowIndex int) (string, error) {
+func (p *Processor) processLine(ctx context.Context, line string, parser *parser.Parser, startRowIndex int) (string, error) {
 	var tableName string
 	preparseResult := preparse(line)
 	switch v := preparseResult.(type) {
@@ -402,6 +411,13 @@ func (p Processor) processLine(ctx context.Context, line string, parser *parser.
 	case preparsedStatementWithTable:
 		tableName = v.GetTableName()
 	}
+	// Track all CREATE TABLE names at preparse level (before config lookup — works with empty configs)
+	if _, isCreate := preparseResult.(preparsedCreateStmt); isCreate {
+		p.schemaMapLock.Lock()
+		p.processedTables = append(p.processedTables, tableName)
+		p.schemaMapLock.Unlock()
+	}
+
 	tableTransformations, ok := p.tableTransformations[tableName]
 	if !ok {
 		return line, nil // passthrough: table not configured
@@ -444,7 +460,7 @@ func countInsertRows(line string) int {
 	return len(matches) + 1 // +1 for the first tuple
 }
 
-func (p Processor) processLines(input chan string, ctx context.Context) (chan chan string, chan error) {
+func (p *Processor) processLines(input chan string, ctx context.Context) (chan chan string, chan error) {
 	outputCh := make(chan chan string, 100)
 	errCh := make(chan error, 1) // buffered to ensure error is never dropped
 	linesForProcessing := make(chan lineWithOutputChannel, 100)
@@ -550,7 +566,7 @@ var restoreFlags = format.RestoreStringSingleQuotes |
 	format.RestoreNameBackQuotes |
 	format.RestoreStringEscapeBackslash
 
-func (p Processor) Process(input io.Reader, output io.Writer, pCtx context.Context) (err error) {
+func (p *Processor) Process(input io.Reader, output io.Writer, pCtx context.Context) (err error) {
 	readLines, inputErrors := readStatements(input, pCtx)
 	processedLinesChans, processingErrors := p.processLines(readLines, pCtx)
 	done := make(chan error, 1)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -646,9 +646,6 @@ func prepareTableConfigs(configData config.Config) (map[string]*PreparedTableCon
 	}
 	for _, tableConfig := range configData.TableConfigs {
 		preparedTableConfig, err := func() (*PreparedTableConfig, error) {
-			if tableConfig.Skip {
-				return &PreparedTableConfig{Skip: true}, nil
-			}
 			allTemplates := make(map[string]config.Template)
 			for name, tmpl := range configData.TableVariables {
 				allTemplates[".TableVariables."+name] = tmpl
@@ -762,7 +759,6 @@ func prepareTableConfigs(configData config.Config) (map[string]*PreparedTableCon
 				return nil, fmt.Errorf("cannot render table variables: %w", err)
 			}
 			preparedTableConfig := &PreparedTableConfig{
-				Skip:                    tableConfig.Skip,
 				GlobalVariables:         renderedGlobalVariables,
 				TableVariables:          rendererTableVariables,
 				RowVariableTemplates:    rowVariableTemplates,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -67,6 +67,9 @@ func NewProcessor(config config.Config) (*Processor, error) {
 	return p, nil
 }
 
+// ProcessedTables returns a sorted list of all table names encountered in
+// CREATE TABLE statements during the most recent Process() call.
+// Must be called after Process() returns.
 func (p *Processor) ProcessedTables() []string {
 	result := make([]string, len(p.processedTables))
 	copy(result, p.processedTables)
@@ -567,6 +570,7 @@ var restoreFlags = format.RestoreStringSingleQuotes |
 	format.RestoreStringEscapeBackslash
 
 func (p *Processor) Process(input io.Reader, output io.Writer, pCtx context.Context) (err error) {
+	p.processedTables = nil // reset for this call
 	readLines, inputErrors := readStatements(input, pCtx)
 	processedLinesChans, processingErrors := p.processLines(readLines, pCtx)
 	done := make(chan error, 1)
@@ -642,7 +646,7 @@ func prepareTableConfigs(configData config.Config) (map[string]*PreparedTableCon
 	}
 	for _, tableConfig := range configData.TableConfigs {
 		preparedTableConfig, err := func() (*PreparedTableConfig, error) {
-			if tableConfig.Skip && len(tableConfig.Columns) == 0 {
+			if tableConfig.Skip {
 				return &PreparedTableConfig{Skip: true}, nil
 			}
 			allTemplates := make(map[string]config.Template)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -398,6 +398,12 @@ func (p Processor) processLine(ctx context.Context, line string, parser *parser.
 	if !ok {
 		return line, nil // passthrough: table not configured
 	}
+	// Skip INSERT statements for tables with Skip=true (before AST parsing for performance)
+	if tableTransformations.Skip {
+		if _, isInsert := preparseResult.(preparsedInsertStmt); isInsert {
+			return "", nil
+		}
+	}
 	parseResult, _, err := parser.Parse(line, mysql.UTF8Charset, mysql.UTF8Charset)
 	if err != nil {
 		return line, fmt.Errorf("cannot parse statement for table %s: %w", tableName, err)
@@ -595,6 +601,7 @@ type PreparedColumnOp struct {
 }
 
 type PreparedTableConfig struct {
+	Skip                    bool
 	ColumnOps               map[string][]PreparedColumnOp
 	ColumnTemplates         map[string][]*templates.Template
 	ColumnVariableTemplates map[string]*templates.Template
@@ -611,6 +618,9 @@ func prepareTableConfigs(configData config.Config) (map[string]*PreparedTableCon
 	}
 	for _, tableConfig := range configData.TableConfigs {
 		preparedTableConfig, err := func() (*PreparedTableConfig, error) {
+			if tableConfig.Skip && len(tableConfig.Columns) == 0 {
+				return &PreparedTableConfig{Skip: true}, nil
+			}
 			allTemplates := make(map[string]config.Template)
 			for name, tmpl := range configData.TableVariables {
 				allTemplates[".TableVariables."+name] = tmpl
@@ -724,6 +734,7 @@ func prepareTableConfigs(configData config.Config) (map[string]*PreparedTableCon
 				return nil, fmt.Errorf("cannot render table variables: %w", err)
 			}
 			preparedTableConfig := &PreparedTableConfig{
+				Skip:                    tableConfig.Skip,
 				GlobalVariables:         renderedGlobalVariables,
 				TableVariables:          rendererTableVariables,
 				RowVariableTemplates:    rowVariableTemplates,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -41,6 +41,14 @@ func NewProcessor(config config.Config) (*Processor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to prepare transformations: %w", err)
 	}
+	// Expand SkipTables shorthand into tableTransformations
+	for _, tableName := range config.SkipTables {
+		if existing, ok := tableTransformations[tableName]; ok {
+			existing.Skip = true
+		} else {
+			tableTransformations[tableName] = &PreparedTableConfig{Skip: true}
+		}
+	}
 	schemaLock := &sync.Mutex{}
 	p := &Processor{
 		Config:               config,

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -921,6 +921,36 @@ func TestProcessor_ProcessedTables_ReturnsNewSlice(t *testing.T) {
 	}
 }
 
+func TestProcessor_ProcessedTables_ResetsOnSecondProcess(t *testing.T) {
+	cfg := config.Config{}
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	// First Process call with users.sql
+	input1 := strings.NewReader(loadFixture(t, "users.sql"))
+	err = processor.Process(input1, &bytes.Buffer{}, context.Background())
+	if err != nil {
+		t.Fatalf("First Process failed: %v", err)
+	}
+	tables1 := processor.ProcessedTables()
+	if len(tables1) != 1 || tables1[0] != "users" {
+		t.Fatalf("Expected [users] after first Process, got %v", tables1)
+	}
+
+	// Second Process call with orders.sql
+	input2 := strings.NewReader(loadFixture(t, "orders.sql"))
+	err = processor.Process(input2, &bytes.Buffer{}, context.Background())
+	if err != nil {
+		t.Fatalf("Second Process failed: %v", err)
+	}
+	tables2 := processor.ProcessedTables()
+	if len(tables2) != 1 || tables2[0] != "orders" {
+		t.Errorf("Expected [orders] after second Process (reset), got %v", tables2)
+	}
+}
+
 func TestProcessor_SkipTable_WithColumnConfigs_SkipTakesPrecedence(t *testing.T) {
 	cfg := config.Config{
 		SkipTables: []string{"audit_log"},

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -762,6 +762,58 @@ func TestProcessor_SkipTable_DropsInsert(t *testing.T) {
 	}
 }
 
+func TestProcessor_SkipTables_Shorthand(t *testing.T) {
+	cfg := config.Config{
+		SkipTables: []string{"audit_log"},
+	}
+
+	input := loadFixture(t, "audit_log.sql")
+	output, err := processSQL(t, cfg, input)
+	if err != nil {
+		t.Fatalf("Failed to process SQL: %v", err)
+	}
+
+	if !strings.Contains(output, "CREATE TABLE") {
+		t.Error("CREATE TABLE should be preserved")
+	}
+	lowered := strings.ToLower(output)
+	if strings.Contains(lowered, "insert into") {
+		t.Error("INSERT should be dropped for tables in SkipTables")
+	}
+}
+
+func TestProcessor_SkipTables_MergesWithExistingTableConfig(t *testing.T) {
+	cfg := config.Config{
+		SkipTables: []string{"users"},
+		TableConfigs: []config.TableConfig{
+			{
+				TableName: "users",
+				Columns: []config.ColumnConfig{
+					{
+						ColumnName: "email",
+						Templates:  []config.Template{"anon@test.com"},
+					},
+				},
+			},
+		},
+	}
+
+	input := loadFixture(t, "users.sql")
+	output, err := processSQL(t, cfg, input)
+	if err != nil {
+		t.Fatalf("Failed to process SQL: %v", err)
+	}
+
+	lowered := strings.ToLower(output)
+	// Skip takes precedence — INSERT should be dropped entirely, not transformed
+	if strings.Contains(lowered, "insert into") {
+		t.Error("INSERT should be dropped when SkipTables overrides TableConfig")
+	}
+	if strings.Contains(output, "anon@test.com") {
+		t.Error("Transformations should not be applied when skip takes precedence")
+	}
+}
+
 // Benchmark configuration for anonymizing benchmark_users table
 func benchmarkConfig() config.Config {
 	return config.Config{

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -737,31 +737,6 @@ func TestProcessor_JsonTransform_FromJSONConfig(t *testing.T) {
 	}
 }
 
-func TestProcessor_SkipTable_DropsInsert(t *testing.T) {
-	cfg := config.Config{
-		TableConfigs: []config.TableConfig{
-			{
-				TableName: "audit_log",
-				Skip:      true,
-			},
-		},
-	}
-
-	input := loadFixture(t, "audit_log.sql")
-	output, err := processSQL(t, cfg, input)
-	if err != nil {
-		t.Fatalf("Failed to process SQL: %v", err)
-	}
-
-	if !strings.Contains(output, "CREATE TABLE") {
-		t.Error("CREATE TABLE should be preserved for skipped tables")
-	}
-	lowered := strings.ToLower(output)
-	if strings.Contains(lowered, "insert into") {
-		t.Error("INSERT should be dropped for skipped tables")
-	}
-}
-
 func TestProcessor_SkipTables_Shorthand(t *testing.T) {
 	cfg := config.Config{
 		SkipTables: []string{"audit_log"},
@@ -948,10 +923,10 @@ func TestProcessor_ProcessedTables_ReturnsNewSlice(t *testing.T) {
 
 func TestProcessor_SkipTable_WithColumnConfigs_SkipTakesPrecedence(t *testing.T) {
 	cfg := config.Config{
+		SkipTables: []string{"audit_log"},
 		TableConfigs: []config.TableConfig{
 			{
 				TableName: "audit_log",
-				Skip:      true,
 				Columns: []config.ColumnConfig{
 					{
 						ColumnName: "details",

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -737,6 +737,31 @@ func TestProcessor_JsonTransform_FromJSONConfig(t *testing.T) {
 	}
 }
 
+func TestProcessor_SkipTable_DropsInsert(t *testing.T) {
+	cfg := config.Config{
+		TableConfigs: []config.TableConfig{
+			{
+				TableName: "audit_log",
+				Skip:      true,
+			},
+		},
+	}
+
+	input := loadFixture(t, "audit_log.sql")
+	output, err := processSQL(t, cfg, input)
+	if err != nil {
+		t.Fatalf("Failed to process SQL: %v", err)
+	}
+
+	if !strings.Contains(output, "CREATE TABLE") {
+		t.Error("CREATE TABLE should be preserved for skipped tables")
+	}
+	lowered := strings.ToLower(output)
+	if strings.Contains(lowered, "insert into") {
+		t.Error("INSERT should be dropped for skipped tables")
+	}
+}
+
 // Benchmark configuration for anonymizing benchmark_users table
 func benchmarkConfig() config.Config {
 	return config.Config{

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -814,6 +814,138 @@ func TestProcessor_SkipTables_MergesWithExistingTableConfig(t *testing.T) {
 	}
 }
 
+func TestProcessor_ProcessedTables_EmptyInput(t *testing.T) {
+	cfg := config.Config{}
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	input := strings.NewReader("")
+	err = processor.Process(input, &bytes.Buffer{}, context.Background())
+	if err != nil {
+		t.Fatalf("Failed to process: %v", err)
+	}
+
+	tables := processor.ProcessedTables()
+	if len(tables) != 0 {
+		t.Errorf("Expected empty table list, got %v", tables)
+	}
+}
+
+func TestProcessor_ProcessedTables_SingleTable(t *testing.T) {
+	cfg := config.Config{}
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	input := strings.NewReader(loadFixture(t, "users.sql"))
+	err = processor.Process(input, &bytes.Buffer{}, context.Background())
+	if err != nil {
+		t.Fatalf("Failed to process: %v", err)
+	}
+
+	tables := processor.ProcessedTables()
+	if len(tables) != 1 {
+		t.Fatalf("Expected 1 table, got %d: %v", len(tables), tables)
+	}
+	if tables[0] != "users" {
+		t.Errorf("Expected 'users', got '%s'", tables[0])
+	}
+}
+
+func TestProcessor_ProcessedTables_MultipleTables_Sorted(t *testing.T) {
+	cfg := config.Config{}
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	fixture := loadFixture(t, "users.sql") + loadFixture(t, "orders.sql")
+	input := strings.NewReader(fixture)
+	err = processor.Process(input, &bytes.Buffer{}, context.Background())
+	if err != nil {
+		t.Fatalf("Failed to process: %v", err)
+	}
+
+	tables := processor.ProcessedTables()
+	if len(tables) != 2 {
+		t.Fatalf("Expected 2 tables, got %d: %v", len(tables), tables)
+	}
+	if tables[0] != "orders" || tables[1] != "users" {
+		t.Errorf("Expected [orders, users], got %v", tables)
+	}
+}
+
+func TestProcessor_ProcessedTables_SkippedTablesStillAppear(t *testing.T) {
+	cfg := config.Config{
+		SkipTables: []string{"audit_log"},
+	}
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	fixture := loadFixture(t, "audit_log.sql") + loadFixture(t, "users.sql")
+	input := strings.NewReader(fixture)
+	err = processor.Process(input, &bytes.Buffer{}, context.Background())
+	if err != nil {
+		t.Fatalf("Failed to process: %v", err)
+	}
+
+	tables := processor.ProcessedTables()
+	if len(tables) != 2 {
+		t.Fatalf("Expected 2 tables, got %d: %v", len(tables), tables)
+	}
+	found := map[string]bool{}
+	for _, name := range tables {
+		found[name] = true
+	}
+	if !found["audit_log"] {
+		t.Error("Skipped table 'audit_log' should still appear in ProcessedTables")
+	}
+	if !found["users"] {
+		t.Error("Table 'users' should appear in ProcessedTables")
+	}
+}
+
+func TestProcessor_ProcessedTables_BeforeProcess(t *testing.T) {
+	cfg := config.Config{}
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	tables := processor.ProcessedTables()
+	if len(tables) != 0 {
+		t.Errorf("Expected empty list before Process(), got %v", tables)
+	}
+}
+
+func TestProcessor_ProcessedTables_ReturnsNewSlice(t *testing.T) {
+	cfg := config.Config{}
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create processor: %v", err)
+	}
+
+	input := strings.NewReader(loadFixture(t, "users.sql"))
+	err = processor.Process(input, &bytes.Buffer{}, context.Background())
+	if err != nil {
+		t.Fatalf("Failed to process: %v", err)
+	}
+
+	tables1 := processor.ProcessedTables()
+	tables2 := processor.ProcessedTables()
+	if len(tables1) > 0 {
+		tables1[0] = "MUTATED"
+	}
+	if len(tables2) > 0 && tables2[0] == "MUTATED" {
+		t.Error("ProcessedTables should return a new slice each call")
+	}
+}
+
 // Benchmark configuration for anonymizing benchmark_users table
 func benchmarkConfig() config.Config {
 	return config.Config{

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -946,6 +946,109 @@ func TestProcessor_ProcessedTables_ReturnsNewSlice(t *testing.T) {
 	}
 }
 
+func TestProcessor_SkipTable_WithColumnConfigs_SkipTakesPrecedence(t *testing.T) {
+	cfg := config.Config{
+		TableConfigs: []config.TableConfig{
+			{
+				TableName: "audit_log",
+				Skip:      true,
+				Columns: []config.ColumnConfig{
+					{
+						ColumnName: "details",
+						Templates:  []config.Template{"REDACTED"},
+					},
+				},
+			},
+		},
+	}
+
+	input := loadFixture(t, "audit_log.sql")
+	output, err := processSQL(t, cfg, input)
+	if err != nil {
+		t.Fatalf("Failed to process SQL: %v", err)
+	}
+
+	lowered := strings.ToLower(output)
+	if strings.Contains(lowered, "insert into") {
+		t.Error("INSERT should be dropped even when column configs exist (skip takes precedence)")
+	}
+	if strings.Contains(output, "REDACTED") {
+		t.Error("Column transformations should not run when skip is true")
+	}
+	if !strings.Contains(output, "CREATE TABLE") {
+		t.Error("CREATE TABLE should be preserved")
+	}
+}
+
+func TestProcessor_SkipTable_Mixed_SkipAndTransformAndPassthrough(t *testing.T) {
+	cfg := config.Config{
+		SkipTables: []string{"audit_log"},
+		TableConfigs: []config.TableConfig{
+			{
+				TableName: "users",
+				Columns: []config.ColumnConfig{
+					{
+						ColumnName: "email",
+						Templates:  []config.Template{"anon@test.com"},
+					},
+				},
+			},
+		},
+	}
+
+	// audit_log = skipped, users = transformed, orders = passthrough
+	input := loadFixture(t, "audit_log.sql") + loadFixture(t, "users.sql") + loadFixture(t, "orders.sql")
+	output, err := processSQL(t, cfg, input)
+	if err != nil {
+		t.Fatalf("Failed to process SQL: %v", err)
+	}
+
+	// audit_log: CREATE preserved, INSERT dropped
+	if !strings.Contains(output, "CREATE TABLE `audit_log`") {
+		t.Error("audit_log CREATE TABLE should be preserved")
+	}
+	lowered := strings.ToLower(output)
+	if strings.Contains(lowered, "'login'") {
+		t.Error("audit_log INSERT data should be dropped")
+	}
+
+	// users: transformed
+	if !strings.Contains(output, "anon@test.com") {
+		t.Error("users email should be anonymized")
+	}
+	if strings.Contains(output, "john.doe@example.com") {
+		t.Error("Original email should not be present")
+	}
+
+	// orders: passthrough
+	if !strings.Contains(output, "99.99") {
+		t.Error("orders should pass through unchanged")
+	}
+}
+
+func TestProcessor_SkipTable_MultiValueInsert(t *testing.T) {
+	cfg := config.Config{
+		SkipTables: []string{"items"},
+	}
+
+	input := loadFixture(t, "items.sql")
+	output, err := processSQL(t, cfg, input)
+	if err != nil {
+		t.Fatalf("Failed to process SQL: %v", err)
+	}
+
+	if !strings.Contains(output, "CREATE TABLE") {
+		t.Error("CREATE TABLE should be preserved")
+	}
+	lowered := strings.ToLower(output)
+	if strings.Contains(lowered, "insert into") {
+		t.Error("Multi-value INSERT should be dropped entirely")
+	}
+	if strings.Contains(output, "Item One") {
+		t.Error("INSERT data should not be present")
+	}
+}
+
 // Benchmark configuration for anonymizing benchmark_users table
 func benchmarkConfig() config.Config {
 	return config.Config{

--- a/processor/testdata/fixtures/audit_log.sql
+++ b/processor/testdata/fixtures/audit_log.sql
@@ -1,0 +1,13 @@
+-- Test fixture: audit_log table for skip testing
+
+DROP TABLE IF EXISTS `audit_log`;
+CREATE TABLE `audit_log` (
+  `id` bigint(20) NOT NULL,
+  `action` varchar(100) NOT NULL,
+  `user_id` bigint(20) NOT NULL,
+  `details` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO `audit_log` VALUES (1,'login',42,'User logged in from 192.168.1.1');
+INSERT INTO `audit_log` VALUES (2,'update',42,'Changed email to new@example.com');


### PR DESCRIPTION
## Summary

- Add per-table `Skip` flag and top-level `SkipTables` shorthand to drop INSERT statements while preserving CREATE TABLE
- Add `ProcessedTables()` method returning sorted list of all tables encountered in CREATE TABLE statements (works with empty configs)
- Skip check happens before AST parsing for zero overhead on skipped tables

## Design

See `handoffs/2026-02-17-skip-tables-design.md` (not committed — in `.gitignore`).

Consumer is db-hub:
- **Import**: filter out data for selected tables via `SkipTables`
- **Dump creation**: collect table list via `ProcessedTables()` with empty config

## Test plan
- [x] Per-table skip: INSERT dropped, CREATE TABLE preserved
- [x] SkipTables shorthand equivalent to per-table skip
- [x] SkipTables merges with existing TableConfig (skip takes precedence)
- [x] Skip + column configs: skip wins, transforms don't run
- [x] Mixed: skip + transform + passthrough tables in single stream
- [x] Multi-value INSERT fully dropped for skipped tables
- [x] ProcessedTables: empty input, single table, multiple sorted, skipped tables still appear
- [x] ProcessedTables: returns new slice each call, empty before Process()
- [x] processedTables resets between Process() calls
- [x] All existing tests pass, go vet clean, gofmt clean